### PR TITLE
Allow for multiple sort criteria and custom sort

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -10,6 +10,11 @@ var itemsjs = require('itemsjs')(data, {
       field: 'year',
       // possible values asc or desc
       order: 'asc'
+    },
+    year_name_asc: {
+      // Multiple criteria possible
+      field: ['date', 'name'],
+      order: ['asc', 'asc']
     }
   },
   aggregations: {
@@ -51,7 +56,11 @@ var movies = itemsjs.search({
 // full text search
 var movies = itemsjs.search({
   per_page: 1,
-  sort: 'name_asc',
+  sort: {
+    // Custom sort not defined in configuration
+    field: 'year',
+    order: 'asc'
+  },
   filters: {
     tags: ['1980s']
   }

--- a/src/lib.js
+++ b/src/lib.js
@@ -115,13 +115,15 @@ module.exports.aggregation = function(items, input, aggregations) {
  * return items by sort
  */
 module.exports.sorted_items = function(items, sort, sortings) {
+  if (sortings && sortings[sort]) {
+    sort = sortings[sort];
+  }
 
-  if (sortings[sort] && sortings[sort].field) {
-
+  if (sort.field) {
     return _.orderBy(
       items,
-      [sortings[sort].field],
-      [sortings[sort].order || 'asc']
+      sort.field,
+      sort.order || 'asc'
     );
   }
 

--- a/tests/sortingsSpec.js
+++ b/tests/sortingsSpec.js
@@ -11,12 +11,16 @@ describe('aggregations', function() {
 
   var items = [{
     name: 'movie1',
+    date: '2018-12-03',
   }, {
     name: 'movie7',
+    date: '2018-12-01',
   }, {
     name: 'movie3',
+    date: '2018-12-02',
   }, {
     name: 'movie2',
+    date: '2018-12-01',
   }]
 
   it('makes items sorting', function test(done) {
@@ -29,6 +33,10 @@ describe('aggregations', function() {
       name_desc: {
         field: 'name',
         order: 'desc'
+      },
+      date_asc: {
+        field: ['date', 'name'],
+        order: ['asc', 'asc']
       }
     }
 
@@ -37,6 +45,16 @@ describe('aggregations', function() {
 
     var result = service.sorted_items(items, 'name_desc', sortings);
     assert.deepEqual(_.map(result, 'name'), ['movie1', 'movie2', 'movie3', 'movie7'].reverse());
+
+    var result = service.sorted_items(items, 'date_asc', sortings);
+    assert.deepEqual(_.map(result, 'name'), ['movie2', 'movie7', 'movie3', 'movie1']);
+
+    var customSort = {
+      field: ['date', 'name'],
+      order: ['desc', 'desc']
+    }
+    var result = service.sorted_items(items, customSort);
+    assert.deepEqual(_.map(result, 'name'), ['movie1', 'movie3', 'movie7', 'movie2']);
     done();
   });
 });


### PR DESCRIPTION
Hello,

I made some changes to allow a multiple criteria sort, as is allowed by `_.orderBy`.
I've also added the possibility to use a custom sort which was not defined in the configuration, in case the sort criteria are built on the fly.

I added tests and updated docs, please let me know if I need to do anything more !

Thank you.