### PR TITLE
Add option to remove stemmer and/or stopWordFilter of lunr.

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,9 +158,7 @@ Responsible for defining global configuration. Look for full example here - [con
 
   * **<code>prefilter</code>** function which narrows items down in custom way i.e. with filter or slice. [See example](/docs/configuration.md)
   
-  * **<code>removeStemmer</code>** set to `true` if you want to remove the [stemmer functionality of lunr](https://github.com/olivernn/lunr.js/issues/328).
-
-  * **<code>removeStopWordFilter</code>** set to `true` if you want to remove the [stopWordFilter functionality of lunr](https://github.com/olivernn/lunr.js/issues/233).
+  * **<code>isExactSearch</code>** set to `true` if you want to always show exact search matches. See [lunr stemmer](https://github.com/olivernn/lunr.js/issues/328) and [lunr stopWordFilter](https://github.com/olivernn/lunr.js/issues/233).
 
 ### itemsjs.aggregation(options)
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Responsible for defining global configuration. Look for full example here - [con
   * **<code>filter</code>** function responsible for items filtering. The way of working is similar to js [native filter function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter). [See example](/docs/configuration.md)
 
   * **<code>prefilter</code>** function which narrows items down in custom way i.e. with filter or slice. [See example](/docs/configuration.md)
+  
+  * **<code>removeStemmer</code>** set to `true` if you want to remove the [stemmer functionality of lunr](https://github.com/olivernn/lunr.js/issues/328).
+
+  * **<code>removeStopWordFilter</code>** set to `true` if you want to remove the [stopWordFilter functionality of lunr](https://github.com/olivernn/lunr.js/issues/233).
 
 ### itemsjs.aggregation(options)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,7 +35,9 @@ var itemsjs = require('itemsjs')(data, {
       size: 5
     }
   },
-  searchableFields: ['name', 'tags']
+  searchableFields: ['name', 'tags'],
+  removeStemmer: false, // Default false
+  removeStopWordFilter: false // Default false
 });
 ```
 
@@ -84,13 +86,5 @@ var result = itemsjs.search({
       return item.price > 100;
     });
   }
-});
-```
-
-```js
-var result = itemsjs.search({
-  query: 'shoes',
-  removeStemmer: true,
-  removeStopWordFilter: true
 });
 ```

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,8 +36,7 @@ var itemsjs = require('itemsjs')(data, {
     }
   },
   searchableFields: ['name', 'tags'],
-  removeStemmer: false, // Default false
-  removeStopWordFilter: false // Default false
+  isExactSearch: true // Default false
 });
 ```
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -86,3 +86,11 @@ var result = itemsjs.search({
   }
 });
 ```
+
+```js
+var result = itemsjs.search({
+  query: 'shoes',
+  removeStemmer: true,
+  removeStopWordFilter: true
+});
+```

--- a/src/fulltext.js
+++ b/src/fulltext.js
@@ -22,14 +22,12 @@ var Fulltext = function(items, config) {
     this.ref('id');
 
     /**
-     * Remove the stemmer and/or stopWordFilter from the pipeline 
+     * Remove the stemmer and stopWordFilter from the pipeline 
      * stemmer: https://github.com/olivernn/lunr.js/issues/328
      * stopWordFilter: https://github.com/olivernn/lunr.js/issues/233
      */
-    if (config.removeStemmer) {
+    if (config.isExactSearch) {
       this.pipeline.remove(lunr.stemmer)
-    }
-    if (config.removeStopWordFilter) {
       this.pipeline.remove(lunr.stopWordFilter)
     }
   })

--- a/src/fulltext.js
+++ b/src/fulltext.js
@@ -20,6 +20,18 @@ var Fulltext = function(items, config) {
       self.field(field);
     });
     this.ref('id');
+
+    /**
+     * Remove the stemmer and/or stopWordFilter from the pipeline 
+     * stemmer: https://github.com/olivernn/lunr.js/issues/328
+     * stopWordFilter: https://github.com/olivernn/lunr.js/issues/233
+     */
+    if (config.removeStemmer) {
+      this.pipeline.remove(lunr.stemmer)
+    }
+    if (config.removeStopWordFilter) {
+      this.pipeline.remove(lunr.stopWordFilter)
+    }
   })
   //var items2 = _.clone(items)
   var i = 1;

--- a/tests/fulltextSpec.js
+++ b/tests/fulltextSpec.js
@@ -53,8 +53,7 @@ describe('fulltext', function() {
   it('makes search stepping through characters', function test(done) {
     var fulltext = new Fulltext(specialItems, {
       searchableFields: ['name'],
-      removeStemmer: true,
-      removeStopWordFilter: true
+      isExactSearch: true
     });
     assert.equal(fulltext.search('e').length, 1);
     assert.equal(fulltext.search('el').length, 1);

--- a/tests/fulltextSpec.js
+++ b/tests/fulltextSpec.js
@@ -17,6 +17,11 @@ describe('fulltext', function() {
     tags: ['running', 'vietnam'],
   }];
 
+  var specialItems = [
+    {"name": "elation"},
+    {"name": "source"}
+ ]
+
   it('checks search', function test(done) {
 
     var fulltext = new Fulltext(items);
@@ -44,4 +49,27 @@ describe('fulltext', function() {
     done();
   });
 
+
+  it('makes search stepping through characters', function test(done) {
+    var fulltext = new Fulltext(specialItems, {
+      searchableFields: ['name'],
+      removeStemmer: true,
+      removeStopWordFilter: true
+    });
+    assert.equal(fulltext.search('e').length, 1);
+    assert.equal(fulltext.search('el').length, 1);
+    assert.equal(fulltext.search('ela').length, 1);
+    assert.equal(fulltext.search('elat').length, 1);
+    assert.equal(fulltext.search('elati').length, 1); // Does not appear when stemmer is present
+    assert.equal(fulltext.search('elatio').length, 1);
+    assert.equal(fulltext.search('elation').length, 1);
+    assert.equal(fulltext.search('s').length, 1);
+    assert.equal(fulltext.search('so').length, 1); // Filtered by stopWordFilter
+    assert.equal(fulltext.search('sou').length, 1);
+    assert.equal(fulltext.search('sour').length, 1);
+    assert.equal(fulltext.search('sourc').length, 1);
+    assert.equal(fulltext.search('source').length, 1);
+
+    done();
+  });
 });


### PR DESCRIPTION
I had issues with certain search queries where my expected results were not showing up.
See attached testcase for this.

Apparently the stemmer could lead to unexpected results.
Same goes for stopWords, filtered by the stopWordFilter, are filtered out when it would partially match your word you are searching for.

Added the options to be able to remove the stemmer and stopWordFilter for this.
I chose for the addition of this configuration option to not break any existing functionality.