### PR TITLE
Fixing default title coming from configuration of aggregations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itemsjs",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Created to perform fast search on small json dataset (up to 1000 elements).",
   "main": "lib/index.js",
   "scripts": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -201,11 +201,13 @@ const getBuckets = function(data, input, aggregations) {
     let order;
     let sort;
     let size;
+    let title;
 
     if (aggregations[k]) {
       order = aggregations[k].order;
       sort = aggregations[k].sort;
       size = aggregations[k].size;
+      title = aggregations[k].title;
     }
 
     let buckets = _.chain(v)
@@ -235,7 +237,7 @@ const getBuckets = function(data, input, aggregations) {
 
     return {
       name: k,
-      title: humanize(k),
+      title: title || humanize(k),
       position: position++,
       buckets: buckets
     };

--- a/tests/facetsSpec.js
+++ b/tests/facetsSpec.js
@@ -40,11 +40,11 @@ describe('conjunctive search', function() {
 
   const aggregations = {
     tags: {
-      title: 'Tags',
+      //title: 'Tags',
       conjunction: true,
     },
     actors: {
-      title: 'Actors',
+      title: 'Stars',
       conjunction: true,
     },
     category: {
@@ -102,6 +102,9 @@ describe('conjunctive search', function() {
     //console.log(buckets.tags.buckets);
     assert.deepEqual(buckets.tags.buckets[0].doc_count, 3);
     assert.deepEqual(buckets.tags.buckets[0].key, 'c');
+    assert.deepEqual(buckets.tags.title, 'Tags');
+    assert.deepEqual(buckets.actors.title, 'Stars');
+    assert.deepEqual(buckets.category.title, 'Category');
 
 
 


### PR DESCRIPTION
See itemsapi/itemsjs#78

A simple fix to take default title from the configuration if it exists, using `humanize` otherwise.

- fixed title defaulting from configuration of aggregations
- changed the `conjunctive search` test 
  - to redefine the test aggregation object with different cases of title (unset, different from id. equal to id)  
  - to include asserts on the computed title of each bucket
