### PR TITLE
Feature calculate facet_stats on numeric aggregation key values.

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,7 +32,9 @@ var itemsjs = require('itemsjs')(data, {
       // it is sorting by value (not by count). 'count' is the default
       sort: 'term',
       order: 'asc',
-      size: 5
+      size: 5,
+      // If you want to retrieve the min, max, avg, sum rating values from the whole filtered dataset
+      show_facet_stats: true,
     }
   },
   searchableFields: ['name', 'tags'],

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -334,7 +334,6 @@ const getBuckets = function(data, input, aggregations) {
         position: position++,
         buckets: buckets,
         ...(show_facet_stats) && {facet_stats: calculated_facet_stats},
-        test: facet_stats,
       };
   });
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -264,12 +264,14 @@ const getBuckets = function(data, input, aggregations) {
     let sort;
     let size;
     let title;
+    let show_facet_stats
 
     if (aggregations[k]) {
       order = aggregations[k].order;
       sort = aggregations[k].sort;
       size = aggregations[k].size;
       title = aggregations[k].title;
+      show_facet_stats = aggregations[k].show_facet_stats || false
     }
 
     let buckets = _.chain(v)
@@ -289,21 +291,51 @@ const getBuckets = function(data, input, aggregations) {
       })
       .value();
 
-    if (sort === 'term') {
-      buckets = _.orderBy(buckets, ['selected', 'key'], ['desc', order || 'asc']);
-    } else {
-      buckets = _.orderBy(buckets, ['selected', 'doc_count', 'key'], ['desc', order || 'desc', 'asc']);
-    }
+      if (sort === 'term') {
+        buckets = _.orderBy(buckets, ['selected', 'key'], ['desc', order || 'asc']);
+      } else {
+        buckets = _.orderBy(buckets, ['selected', 'doc_count', 'key'], ['desc', order || 'desc', 'asc']);
+      }
 
-    buckets = buckets.slice(0, size || 10);
+      buckets = buckets.slice(0, size || 10);
 
-    return {
-      name: k,
-      title: title || humanize(k),
-      position: position++,
-      buckets: buckets
-    };
+      // Calculate the facet_stats
+      let facet_stats;
+      let calculated_facet_stats;
 
+      if(show_facet_stats) {
+        facet_stats = [];
+         _.chain(v)
+          .toPairs().forEach(v2 => {
+            if(isNaN(v2[0])) {
+              throw new Error("You cant use chars to calculate the facet_stats.");
+            }
+
+            // Doc_count 
+            if(v2[1].array().length > 0) {
+              v2[1].forEach(doc_count => {
+                facet_stats.push(parseInt(v2[0]));
+              });
+            }
+        })
+        .value();
+
+        calculated_facet_stats = {
+          min: _.minBy(facet_stats),
+          max: _.maxBy(facet_stats),
+          avg: _.meanBy(facet_stats),
+          sum: _.sumBy(facet_stats),
+        };
+      }
+              
+      return {
+        name: k,
+        title: title || humanize(k),
+        position: position++,
+        buckets: buckets,
+        ...(show_facet_stats) && {facet_stats: calculated_facet_stats},
+        test: facet_stats,
+      };
   });
 };
 

--- a/tests/browserifySpec.js
+++ b/tests/browserifySpec.js
@@ -217,6 +217,78 @@ describe('itemjs general tests', function() {
     done();
   });
 
+  it('makes aggregations with facet_stats', function test(done) {
+    const items = [{
+      name: 'Apple 7',
+      price: 1,
+    }, {
+      name: 'Apple 8',
+      price: 1,
+    }, {
+      name: 'Apple 9',
+      price: '7',
+    }, {
+      name: 'Samsung',
+      price: 7,
+    }, {
+      name: 'Apple 10',
+    }];
+
+    const itemsjs = require('./../index')(items, {
+      aggregations: {
+        price: {
+          title: 'Price',
+          size: 3,
+          show_facet_stats: true
+        }
+      }
+    });
+
+    const result = itemsjs.search({
+      query: 'Apple'
+    });
+    
+    assert.equal(result.data.aggregations.price.facet_stats.min, 1);
+    assert.equal(result.data.aggregations.price.facet_stats.max, 7);
+    assert.equal(result.data.aggregations.price.facet_stats.avg, 3);
+    assert.equal(result.data.aggregations.price.facet_stats.sum, 9);
+
+    done();
+  });
+
+  it('makes aggregations with facet_stats and string values', function test(done) {
+    const items = [{
+      name: 'movie1',
+      tags: '€ 1 euro',
+    }, {
+      name: 'movie2',
+      tags: '€ 1 euro',
+    }, {
+      name: 'movie3',
+      tags: '€ 1 euro',
+    }];
+
+    const itemsjs = require('./../index')(items, {
+      aggregations: {
+        tags: {
+          title: 'Tags',
+          size: 1,
+          show_facet_stats: true,
+        }
+      }
+    });
+    
+    try {
+      itemsjs.search({
+        query: ''
+      });
+    } catch (err) {
+      assert.equal(err.message, 'You cant use chars to calculate the facet_stats.');
+    }
+
+    done();
+  });
+
   xit('makes aggregations for undefined field', function test(done) {
     const items = [{
       name: 'movie1',


### PR DESCRIPTION
Hi @cigolpl ,

For our project we need the facet statistics of the numeric fields e.g. price, this concerns the min, max, avg, and sum values.

With the `allFilteredItems` field, we could have made the calculation ourselves. But by implementing this feature into itemjs everyone can use it, and it is also cleaner for us to get the right data directly from Itemsjs.

I hope you like this functionality. You can use facet_stats optionally, this value is set to false by default.

Let me now what you think about it. :)
