### PR TITLE
Support aggregations not being sorted by selected

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ Responsible for defining global configuration. Look for full example here - [con
   - **`order`** `asc` | `desc`. This can be also an array of orders (if `sort` is also array) 
   - **`show_facet_stats`** `true` | `false` (Default) to retrieve the min, max, avg, sum rating values from the whole filtered dataset
   - **`conjunction`** `true` (Default) stands for an _AND_ query (results have to fit all selected facet-values), `false` for an _OR_ query (results have to fit one of the selected facet-values)
-
+  - **`chosen_filters_on_top`** `true` (Default) Filters that have been selected will appear above those not selected, `false` for filters displaying in the order set out by `sort` and `order` regardless of selected status or not
+  
 - **`sortings`** you can configure different sortings like `tags_asc`, `tags_desc` with options and later use it with one key.
 
 - **`searchableFields`** an array of searchable fields.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -35,6 +35,8 @@ var itemsjs = require('itemsjs')(data, {
       size: 5,
       // If you want to retrieve the min, max, avg, sum rating values from the whole filtered dataset
       show_facet_stats: true,
+      // If you don't want selected filters to be positioned at the top of the filter list
+      chosen_filters_on_top: false
     }
   },
   searchableFields: ['name', 'tags'],

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -264,14 +264,16 @@ const getBuckets = function(data, input, aggregations) {
     let sort;
     let size;
     let title;
-    let show_facet_stats
+    let show_facet_stats;
+    let chosen_filters_on_top;
 
     if (aggregations[k]) {
       order = aggregations[k].order;
       sort = aggregations[k].sort;
       size = aggregations[k].size;
       title = aggregations[k].title;
-      show_facet_stats = aggregations[k].show_facet_stats || false
+      show_facet_stats = aggregations[k].show_facet_stats || false;
+      chosen_filters_on_top = aggregations[k].chosen_filters_on_top !== false;
     }
 
     let buckets = _.chain(v)
@@ -291,13 +293,28 @@ const getBuckets = function(data, input, aggregations) {
       })
       .value();
 
+      let iteratees;
+      let sort_order;
+
       if (_.isArray(sort)) {
-        buckets = _.orderBy(buckets, sort || ['key'], order || ['asc']);
-      } else if (sort === 'term') {
-        buckets = _.orderBy(buckets, ['selected', 'key'], ['desc', order || 'asc']);
+        iteratees = sort || ['key'];
+        sort_order = order || ['asc'];
       } else {
-        buckets = _.orderBy(buckets, ['selected', 'doc_count', 'key'], ['desc', order || 'desc', 'asc']);
+        if (sort === 'term') {
+          iteratees = ['key'];
+          sort_order = [order || 'asc'];
+        } else {
+          iteratees = ['doc_count', 'key'];
+          sort_order = [order || 'desc', 'asc'];
+        }
+
+        if (chosen_filters_on_top) {
+          iteratees.unshift('selected');
+          sort_order.unshift('desc');
+        }
       }
+  
+      buckets = _.orderBy(buckets, iteratees, sort_order);
 
       buckets = buckets.slice(0, size || 10);
 

--- a/tests/facetSortingSpec.js
+++ b/tests/facetSortingSpec.js
@@ -90,5 +90,72 @@ describe('facet sorting', function() {
     done();
   });
 
+  it('sort by selected, key and order by desc, asc if sort is term', function test(done) {
+    const result_array = require('./../index')(items, {
+      aggregations: {
+        genres: {
+          sort: ['selected', 'key'],
+          order: ['desc', 'asc']
+        }
+      }
+    }).aggregation({
+      name: 'genres'
+    });
+
+    const result_term = require('./../index')(items, {
+      aggregations: {
+        genres: {
+          sort: 'term'
+        }
+      }
+    }).aggregation({
+      name: 'genres'
+    });   
+
+    assert.deepEqual(result_array.data.buckets, result_term.data.buckets);
+    
+    done();
+  });
+
+  it('sort by selected if chosen_filters_on_top is not set', function test(done) {
+    
+    const result = require('./../index')(items, {
+      aggregations: {
+        genres: {
+          sort: 'term'
+        }
+      }
+    }).aggregation({
+      name: 'genres',
+      filters: {
+        genres: ['Drama', 'Romance']
+      }
+    });
+
+    assert.deepEqual(result.data.buckets.map(v => v.key), ['Drama', 'Romance', 'Comedy', 'Horror', 'Western']);
+
+    done();    
+  });
+
+  it('does not sort by selected if chosen_filters_on_top is false', function test(done) {
+    
+    const result = require('./../index')(items, {
+      aggregations: {
+        genres: {
+          sort: 'term',
+          chosen_filters_on_top: false
+        }
+      }
+    }).aggregation({
+      name: 'genres',
+      filters: {
+        genres: ['Drama', 'Romance']
+      }
+    });
+
+    assert.deepEqual(result.data.buckets.map(v => v.key), ['Comedy', 'Drama', 'Horror', 'Romance', 'Western']);
+
+    done();    
+  });
 });
 


### PR DESCRIPTION
I found automatic sorting by selected filters on aggregations to be jarring. This PR adds the `chosen_filters_on_top` configuration for aggregations as discussed in #39. The default behaviour is for it to be set to true.

I wasn't quite sure which test file to put the tests so please advise if there is a better place for them.