### PR TITLE
Hide empty filters through configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ Responsible for defining global configuration. Look for full example here - [con
   - **`show_facet_stats`** `true` | `false` (Default) to retrieve the min, max, avg, sum rating values from the whole filtered dataset
   - **`conjunction`** `true` (Default) stands for an _AND_ query (results have to fit all selected facet-values), `false` for an _OR_ query (results have to fit one of the selected facet-values)
   - **`chosen_filters_on_top`** `true` (Default) Filters that have been selected will appear above those not selected, `false` for filters displaying in the order set out by `sort` and `order` regardless of selected status or not
+  - **`hide_zero_doc_count`** `true` | `false` (Default) Hide filters that have 0 results returned
   
 - **`sortings`** you can configure different sortings like `tags_asc`, `tags_desc` with options and later use it with one key.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -39,7 +39,9 @@ var itemsjs = require('itemsjs')(data, {
       // If you want to retrieve the min, max, avg, sum rating values from the whole filtered dataset
       show_facet_stats: true,
       // If you don't want selected filters to be positioned at the top of the filter list
-      chosen_filters_on_top: false
+      chosen_filters_on_top: false,
+      // If you don't want to show filters with no results returned
+      hide_zero_doc_count: true
     }
   },
   searchableFields: ['name', 'tags'],

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -366,7 +366,7 @@ const getBuckets = function(data, input, aggregations) {
           selected: filters.indexOf(v2[0]) !== -1
         };
       })
-      .compact(this)
+      .compact()
       .value();
 
       let iteratees;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -333,6 +333,7 @@ const getBuckets = function(data, input, aggregations) {
     let title;
     let show_facet_stats;
     let chosen_filters_on_top;
+    let hide_zero_doc_count;
 
     if (aggregations[k]) {
       order = aggregations[k].order;
@@ -341,6 +342,7 @@ const getBuckets = function(data, input, aggregations) {
       title = aggregations[k].title;
       show_facet_stats = aggregations[k].show_facet_stats || false;
       chosen_filters_on_top = aggregations[k].chosen_filters_on_top !== false;
+      hide_zero_doc_count = aggregations[k].hide_zero_doc_count || false;
     }
 
     let buckets = _.chain(v)
@@ -352,12 +354,19 @@ const getBuckets = function(data, input, aggregations) {
           filters = input.filters[k];
         }
 
+        let doc_count = v2[1].array().length;
+
+        if (hide_zero_doc_count && doc_count === 0) {
+          return;
+        }
+
         return {
           key: v2[0],
-          doc_count: v2[1].array().length,
+          doc_count: doc_count,
           selected: filters.indexOf(v2[0]) !== -1
         };
       })
+      .compact(this)
       .value();
 
       let iteratees;

--- a/tests/facetSortingSpec.js
+++ b/tests/facetSortingSpec.js
@@ -193,5 +193,25 @@ describe('facet sorting', function() {
 
     done();
   });
+
+  it('excludes filters with zero doc_count if hide_zero_doc_count is true', function test(done) {
+
+    const result = require('./../index')(items, {
+      aggregations: {
+        genres: {
+          hide_zero_doc_count: true
+        }
+      }
+    }).aggregation({
+      name: 'genres',
+      filters: {
+        genres: ['Western']
+      }
+    });
+
+    assert.deepEqual(result.data.buckets.map(v => v.key), ['Western']);
+
+    done();
+  });
 });
 


### PR DESCRIPTION
This implements the second idea in #39. This PR adds the `hide_zero_do_count` configuration value on aggregations that if set to `true` will exclude filters with 0 results.