### PR TITLE
Never  hide selected  facet

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -3,6 +3,7 @@ const FastBitSet = require('fastbitset');
 const booleanParser = require('boolean-parser');
 
 const clone = function(val) {
+ 
 
   try {
     return JSON.parse(JSON.stringify(val));
@@ -356,7 +357,8 @@ const getBuckets = function(data, input, aggregations) {
 
         let doc_count = v2[1].array().length;
 
-        if (hide_zero_doc_count && doc_count === 0) {
+         //hide zero_doc_count facet only if it is not selected
+        if (hide_zero_doc_count && doc_count === 0 && filters.indexOf(v2[0]) === -1) {
           return;
         }
 


### PR DESCRIPTION
Hide zero_count_doc facet only if it is not selected
Sorry , the easiest way to explain why its important -to show this case on my project using itemsjs
[Nobel Prize Laureats 2.0](https://www.nobelists.org/en/all/ )
Please first select 2 citizenships:  Japan & Sweden , then select language spoken: japanese 
You will see that there is no Swedish citizen speaking japanese - zero count facet -but i show it -as it was selected before -so user have possibility to unselect it , otherwise this will be invisible and unselectable  selection
 