### PR TITLE
fix error when filter value not found in items set

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -39,7 +39,7 @@ const combination_indexes = function(facets, filters) {
         const filter_val = disjunctive_filter[1];
 
         filter_keys.push(filter_key);
-        facet_union = facet_union.new_union(facets['bits_data'][filter_key][filter_val]);
+        facet_union = facet_union.new_union(facets['bits_data'][filter_key][filter_val] || new FastBitSet([]));
         indexes[filter_key] = facet_union;
       });
     }
@@ -311,7 +311,7 @@ const facets_ids = function(facets_data, filters) {
     filters.forEach(filter => {
 
       ++i;
-      output = output.new_union(facets_data[field][filter]);
+      output = output.new_union(facets_data[field][filter] || new FastBitSet([]));
     });
   });
 

--- a/tests/searchSpec.js
+++ b/tests/searchSpec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const assert = require('assert');
+const { clone } = require('lodash');
 const items = require('./fixtures/items.json');
 const movies = require('./fixtures/movies.json');
 let itemsjs = require('./../src/index')();
@@ -213,8 +214,10 @@ describe('search', function() {
   
   it('makes search with non existing filter value with conjunction false should return results', function test(done) {
     
-    configuration.aggregations.category.conjunction = false;
-    const itemsjs = require('./../index')(items, configuration);
+    const localConfiguration = clone(configuration);
+    localConfiguration.aggregations.category.conjunction = false;
+
+    const itemsjs = require('./../index')(items, localConfiguration);
 
     const result = itemsjs.search({
       filters: {
@@ -224,6 +227,25 @@ describe('search', function() {
 
     assert.equal(result.data.items.length, 2);
     assert.equal(result.data.aggregations.tags.buckets[0].doc_count, 2);
+
+    done();
+  });
+
+  it('makes search with non existing single filter value with conjunction false should return no results', function test(done) {
+    
+    const localConfiguration = clone(configuration);
+    localConfiguration.aggregations.category.conjunction = false;
+
+    const itemsjs = require('./../index')(items, configuration);
+
+    const result = itemsjs.search({
+      filters: {
+        category: ['thriller']
+      }
+    });
+
+    assert.equal(result.data.items.length, 0);
+    assert.equal(result.data.aggregations.tags.buckets[0].doc_count, 0);
 
     done();
   });

--- a/tests/searchSpec.js
+++ b/tests/searchSpec.js
@@ -28,7 +28,7 @@ describe('search', function() {
       },
       category: {
         title: 'Category',
-        conjunction: true,
+        conjunction: false,
       }
     }
   };
@@ -191,6 +191,22 @@ describe('search', function() {
     });
 
     assert.equal(result.data.items.length, 0);
+
+    done();
+  });
+
+  it('makes search with non existing filter value', function test(done) {
+
+    const itemsjs = require('./../index')(items, configuration);
+
+    const result = itemsjs.search({
+      filters: {
+        category: ['drama', 'thriller']
+      }
+    });
+
+    assert.equal(result.data.items.length, 2);
+    assert.equal(result.data.aggregations.tags.buckets[0].doc_count, 2);
 
     done();
   });

--- a/tests/searchSpec.js
+++ b/tests/searchSpec.js
@@ -28,7 +28,7 @@ describe('search', function() {
       },
       category: {
         title: 'Category',
-        conjunction: false,
+        conjunction: true,
       }
     }
   };
@@ -195,8 +195,25 @@ describe('search', function() {
     done();
   });
 
-  it('makes search with non existing filter value', function test(done) {
+  it('makes search with non existing filter value with conjunction true should return no results', function test(done) {
 
+    const itemsjs = require('./../index')(items, configuration);
+    
+    const result = itemsjs.search({
+      filters: {
+        category: ['drama', 'thriller']
+      }
+    });
+    
+    assert.equal(result.data.items.length, 0);
+    assert.equal(result.data.aggregations.tags.buckets[0].doc_count, 0);
+    
+    done();
+  });
+  
+  it('makes search with non existing filter value with conjunction false should return results', function test(done) {
+    
+    configuration.aggregations.category.conjunction = false;
     const itemsjs = require('./../index')(items, configuration);
 
     const result = itemsjs.search({


### PR DESCRIPTION
It’s my first time contributing to a public repo so let me know if anything needs to be corrected. I added a test to explain the specific usecase covered.

This pr is adding the possibility of having a non existing value in the filters. We want to have a predefined set of filters, but also having the possibility that the filtered data (items) will sometimes not include one of the options.

example: possible filters for categories would be `comedy`, `drama` or `thriller` by default, but the related items would only contains `comedy` or `drama` categories. Added a fallback to an empty `FastBitset` when needed, so it would not break.

Let me know if any changes are necessary and thanks for the lib!