### PR TITLE
Prevent crashing when no items provided

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -247,6 +247,10 @@ export const index = function (items, fields) {
 
   let i = 1;
 
+  fields.forEach((field) => {
+    facets['data'][field] = Object.create(null);
+  });
+
   items && items.map((item) => {
     if (!item['_id']) {
       item['_id'] = i;
@@ -258,13 +262,8 @@ export const index = function (items, fields) {
 
   items && items.map((item) => {
     fields.forEach((field) => {
-      //if (!item || !item[field]) {
       if (!item) {
         return;
-      }
-
-      if (!facets['data'][field]) {
-        facets['data'][field] = Object.create(null);
       }
 
       if (Array.isArray(item[field])) {

--- a/tests/searchSpec.js
+++ b/tests/searchSpec.js
@@ -65,6 +65,25 @@ describe('search', function () {
     done();
   });
 
+  it('searches no items with filters and query', function test(done) {
+    const itemsjs = itemsJS([], configuration);
+
+    const result = itemsjs.search({
+      filters: {
+        tags: ['a'],
+        category: ['drama'],
+      },
+      query: 'comedy',
+    });
+
+    assert.equal(result.data.items.length, 0);
+    assert.equal(result.data.aggregations.in_cinema.buckets.length, 0);
+    assert.equal(result.data.aggregations.category.buckets.length, 0);
+    assert.equal(result.data.aggregations.year.buckets.length, 0);
+
+    done();
+  });
+
   it('searches with two filters', function test(done) {
     const itemsjs = itemsJS(items, configuration);
 
@@ -244,7 +263,7 @@ describe('search', function () {
     } catch (err) {
       assert.equal(
         err.message,
-        '"query" and "filter" options are not working once native search is disabled',
+        '"query" and "filter" options are not working once native search is disabled'
       );
     }
 


### PR DESCRIPTION
Hello there,

I use itemsjs in a Gatsby environnement, my items are loaded through API and sometimes it can return no items.
When no items is provided when indexing, it crashes when doing a search.

The crash occurs when doing a facet union:
![Screenshot 2024-03-19 at 10 23 16 AM](https://github.com/itemsapi/itemsjs/assets/9500684/26cd8e69-106a-4c12-af5f-4e2a78992cd0)


Here is my fix for this issue.
I also added a test for this case in the search spec.

Really appreciate your work with this library.

Thank you for considering my fix.