### PR TITLE
Optimize paging with _ids and facet-only queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "itemsjs",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "itemsjs",
-      "version": "2.4.3",
+      "version": "2.4.4",
       "license": "Apache-2.0",
       "devDependencies": {
         "boolean-parser": "^0.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itemsjs",
-  "version": "2.4.3",
+  "version": "2.4.4",
   "description": "Created to perform fast search on small json dataset (up to 1000 elements).",
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- avoid double materialization of items when using _ids/fulltext: materialize only current page if no sort
- early-exit for per_page=0 (facet-only queries) to skip building items when only aggregations are needed
- bump version to 2.4.4

## Testing
- npm test
